### PR TITLE
improved StaticFlowEntryManager

### DIFF
--- a/Torpedo/src/etri/sdn/controller/module/staticentrymanager/IStaticFlowEntryService.java
+++ b/Torpedo/src/etri/sdn/controller/module/staticentrymanager/IStaticFlowEntryService.java
@@ -118,10 +118,18 @@ public interface IStaticFlowEntryService extends IService {
 	//public Map<String, OFFlowMod> getFlows(String dpid);
 
 	/**
+	 * Reloads static flow entries saved in the memory or DB to a particular switch.
+	 * This is used when the controller is rebooted.
+	 * 
+	 * @throws StaticFlowEntryException 
+	 */
+	public void reloadFlowsToSwitch(String dpid) throws StaticFlowEntryException;
+
+	/**
 	 * Reloads all static flow entries saved in the memory or DB to switches.
 	 * This is used when the controller is rebooted.
 	 * 
 	 * @throws StaticFlowEntryException 
 	 */
-	public void reloadFlowsToSwitch() throws StaticFlowEntryException;
+	public void reloadAllFlowsToSwitch() throws StaticFlowEntryException;
 }

--- a/Torpedo/src/etri/sdn/controller/module/staticentrymanager/OFMStaticFlowEntryManager.java
+++ b/Torpedo/src/etri/sdn/controller/module/staticentrymanager/OFMStaticFlowEntryManager.java
@@ -252,8 +252,13 @@ public class OFMStaticFlowEntryManager extends OFModule implements IStaticFlowEn
 	}
 
 	@Override
-	public void reloadFlowsToSwitch() throws StaticFlowEntryException {
-		flowEntryStorage.reloadFlowModsToSwitch();
+	public void reloadFlowsToSwitch(String dpid) throws StaticFlowEntryException {
+		flowEntryStorage.reloadFlowModsToSwitch(dpid);
+	}
+
+	@Override
+	public void reloadAllFlowsToSwitch() throws StaticFlowEntryException {
+		flowEntryStorage.reloadAllFlowModsToSwitch();
 	}
 
 }

--- a/Torpedo/src/etri/sdn/controller/module/staticentrymanager/StaticFlowEntry.java
+++ b/Torpedo/src/etri/sdn/controller/module/staticentrymanager/StaticFlowEntry.java
@@ -237,7 +237,13 @@ public class StaticFlowEntry {
 				return fac.oxms().ethType(EthType.of(Integer.valueOf(((String) entry.get("eth_type")).replaceAll("0x", ""), 16)));
 			}
 			else if (fieldstr.toLowerCase().equals("ip_proto")) {
-				return fac.oxms().ipProto(IpProtocol.of(Short.valueOf((String) entry.get("ip_proto"))));
+				if ( (fieldstr.toLowerCase().startsWith("0x")) ) {
+					String value = Integer.valueOf(((String) entry.get("ip_proto")).replaceAll("0x", ""), 16).toString();
+					return fac.oxms().ipProto(IpProtocol.of(Short.valueOf(value)));
+				}
+				else {
+					return fac.oxms().ipProto(IpProtocol.of(Short.valueOf((String) entry.get("ip_proto"))));
+				}
 			}
 			else if (fieldstr.toLowerCase().equals("ipv4_src")) {
 				return fac.oxms().ipv4Src(IPv4Address.of(IPv4.toIPv4AddressBytes((String) entry.get("ipv4_src"))));
@@ -348,7 +354,12 @@ public class StaticFlowEntry {
 //				builder.setExact(MatchField.IP_ECN, IpEcn.of((byte) (0b00000011 & b)));
 //			}
 			else if (key.toLowerCase().equals("ip_proto")) {
-				builder.setExact(MatchField.IP_PROTO, IpProtocol.of(Short.valueOf((String) entry.get("ip_proto"))));
+				if ( ((String) entry.get("ip_proto")).startsWith("0x") ) {
+					String value = Integer.valueOf(((String) entry.get("ip_proto")).replaceAll("0x", ""), 16).toString();
+					builder.setExact(MatchField.IP_PROTO, IpProtocol.of(Short.valueOf(value)));
+				} else {
+					builder.setExact(MatchField.IP_PROTO, IpProtocol.of(Short.valueOf((String) entry.get("ip_proto"))));
+				}
 			}
 			else if (key.toLowerCase().equals("ipv4_src")) {
 				if ( builder.get(MatchField.ETH_TYPE) == EthType.ARP ) {


### PR DESCRIPTION
Two modifications

A. 'ip_proto' field in match can be a hexa or decimal format.

B. 'reload' REST API is divided into two types.
- reload all flow entries : /wm/staticflowentry/reload/all/json
- reload flow entries into a specified switch : /wm/staticflowentry/reload/{DPID}/json
- Old version supports the former only : /wm/staticflowentry/reload/json
  Because all REST API are published already, it is needed a careful choice.
